### PR TITLE
enhancement: combine maestro serve and start script, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,223 +2,112 @@
 
 A modern web-based interface for building Maestro agents and workflows using AI assistance.
 
-## Features
+---
 
-- **AI-Powered Chat Interface**: Chat with an AI assistant to help you create Maestro configurations
-- **Real-time YAML Generation**: Automatically generates and updates `agents.yaml` and `workflow.yaml` files
-- **Live Preview**: See your YAML configurations update in real-time as you chat
-- **Persistent Chat Sessions**: Your conversations and YAML files are saved and can be resumed later
-- **Diff Highlighting**: Visual diff view showing additions (green) and deletions (red) in YAML changes
-- **Multiple View Modes**: Toggle between diff view, line numbers, and full YAML display
-- **Save & Download**: Save your configurations locally or download YAML files
-- **Modern UI**: Clean, responsive interface built with React and Tailwind CSS
-- **API Integration**: Connects to the Maestro Builder API for intelligent responses
+## 🚀 Quick Start
 
-## Quick Start
+1. **Clone the repo and enter the directory:**
+   ```bash
+   git clone <your-repo-url>
+   cd maestro-builder
+   ```
 
-### Option 1: Start Both API and Frontend (Recommended)
+2. Set up your environment variables:**
+   - Create a `.env` file （should be the same as maestro one):
 
-```bash
-# From the builder directory
-./start.sh
-```
 
-This will start both the API server and the frontend development server automatically.
+3. **Start everything with one command:**
+   ```bash
+   ./start.sh [agents|workflow]
+   ```
+   - Use `agents` for agent file generation (default if omitted)
+   - Use `workflow` for workflow file generation
 
-### Option 2: Start Components Separately
+   This will:
+   - Start the Maestro backend (with your chosen config)
+   - Start the API server (http://localhost:8001)
+   - Start the frontend (http://localhost:5174)
 
-#### Start the API Server
+4. **Open your browser:**  
+   Go to [http://localhost:5174](http://localhost:5174) to use the Maestro Builder UI.
 
-```bash
-# From the api directory
-cd ../api
-./run.sh
-```
+5. **To stop all services:**
+   ```bash
+   ./stop.sh
+   ```
 
-The API will be available at `http://localhost:8000`
+---
 
-#### Start the Frontend
+## 🛠️ What’s Happening Under the Hood?
 
-```bash
-# From the builder directory
-npm install
-npm run dev
-```
+- **Maestro backend** is started with the correct config for your use case and runs at [http://localhost:8000](http://localhost:8000). This backend is responsible for agent/workflow orchestration and is started by the `maestro serve ...` command.
+- **API server** runs at [http://localhost:8001](http://localhost:8001) (docs at `/docs`).
+- **Frontend** runs at [http://localhost:5174](http://localhost:5174).
+- All logs are saved in the `logs/` directory (`maestro.log`, `api.log`, `builder.log`).
 
-The frontend will be available at `http://localhost:5173`
+---
 
-### Stop All Services
+## 🧑‍💻 Development & Testing
 
-```bash
-# From the builder directory
-./stop.sh
-```
+- **Run tests:**  
+  ```bash
+  pytest tests/
+  ```
+- **Install dependencies:**  
+  ```bash
+  pip install -r api/requirements.txt
+  pip install pytest requests
+  pip install git+https://github.com/AI4quantum/maestro.git@v0.3.0
+  pip install "beeai-framework[duckduckgo]"
+  ```
+- **Frontend dev server:**  
+  ```bash
+  npm install
+  npm run dev
+  ```
 
-This will safely stop both the API server and the frontend development server.
+---
 
-## Usage
+## 📝 Configuration
+- **YAML config files:**  
+  - Agent and workflow YAMLs are in `meta-agents-v2/agents_file_generation/` and `meta-agents-v2/workflow_file_generation/`.
 
-1. **Open the Builder**: Navigate to `http://localhost:5173` in your browser
-2. **Start Chatting**: Type your requirements in the chat input at the bottom
-3. **Watch YAML Generation**: See your `agents.yaml` and `workflow.yaml` files update in real-time
-4. **View Changes**: Use the diff toggle to see highlighted changes (green for additions, red for deletions)
-5. **Switch Views**: Toggle between diff view, line numbers, and full YAML display
-6. **Save Your Work**: Use the save button to persist your configurations
-7. **Download Files**: Use the download buttons in the YAML panel to save your configurations locally
-8. **Manage Sessions**: Use the sidebar to switch between different chat sessions
-9. **Create New Chats**: Click "New Chat" to start fresh with clean initial YAML files
+---
 
-## YAML Panel Features
-
-### View Modes
-- **Diff View** (Default): Shows changes with color-coded highlighting
-  - 🟢 Green background/text for additions
-  - 🔴 Red background/text for deletions
-  - ⚪ Normal text for unchanged lines
-- **Line Numbers**: Displays YAML with line numbers for easy reference
-- **Full View**: Clean YAML display without diff or line numbers
-
-### File Management
-- **Always Shows Both Files**: `agents.yaml` and `workflow.yaml` are always visible
-- **Initial Content**: New chats start with helpful comments explaining what each file is for
-- **Save Button**: Persist your current YAML configurations
-- **Download Button**: Download individual YAML files
-- **Copy to Clipboard**: Quick copy functionality for each file
-
-### Session Management
-- **New Chat Creation**: Creates fresh sessions with clean initial YAML content
-- **Chat History**: All conversations and generated files are automatically saved
-- **Session Switching**: Seamlessly switch between different chat sessions
-- **Session Deletion**: Remove old sessions while maintaining current work
-
-## Example Conversations
-
-### Creating an OpenAI Agent
-```
-User: "Create an OpenAI agent for text summarization"
-AI: "I'll help you create an OpenAI agent for text summarization. Here's the configuration..."
-```
-
-### Building a Workflow
-```
-User: "Build a workflow that processes data and generates reports"
-AI: "I'll create a workflow with multiple steps for data processing and report generation..."
-```
-
-### Complex Requirements
-```
-User: "Create a multi-agent system with a data processor, analyzer, and reporter"
-AI: "I'll design a comprehensive multi-agent system with specialized roles..."
-```
-
-## API Integration
-
-The builder connects to the Maestro Builder API which provides:
-
-- **Intelligent Responses**: AI-powered chat responses using OpenAI (when API key is configured)
-- **Fallback Mode**: Works without OpenAI API key using keyword-based responses
-- **Session Management**: Maintains conversation context across messages with SQLite persistence
-- **YAML Validation**: Ensures generated configurations follow Maestro schemas
-- **Chat History**: Persistent storage of all conversations and generated YAML files
-
-### API Endpoints
-
-- `POST /api/chat_builder_agent` - Send chat messages and get responses
-- `GET /api/get_yamls/{chat_id}` - Retrieve YAML files for a session
-- `GET /api/chat_history` - Get chat history
-- `POST /api/chat_continuation` - Continue an existing chat session
-
-## Configuration
-
-### Environment Variables
-
-Set these in the API directory:
-
-```bash
-export OPENAI_API_KEY="your-openai-api-key"
-```
-
-### API Configuration
-
-The API runs on `http://localhost:8000` by default. You can modify the URL in `src/services/api.ts` if needed.
-
-### Database
-
-The API uses SQLite for persistent storage of:
-- Chat sessions
-- Message history
-- Generated YAML files
-
-The database file is automatically created in the API directory.
-
-## Development
-
-### Project Structure
+## 🗂️ Project Structure
 
 ```
-builder/
-├── src/
-│   ├── components/
-│   │   ├── ChatCanvas.tsx      # Chat message display
-│   │   ├── ChatInput.tsx       # Message input component
-│   │   ├── Sidebar.tsx         # Chat history sidebar
-│   │   └── YamlPanel.tsx       # YAML file display with diff
-│   ├── services/
-│   │   └── api.ts             # API integration service
-│   └── App.tsx                # Main application
-├── start.sh                   # Development startup script
-├── stop.sh                    # Development stop script
-└── package.json
+maestro-builder/
+├── api/                # FastAPI backend
+├── src/                # React frontend
+├── meta-agents-v2/     # Example YAML configs
+├── tests/              # Unit and integration tests
+├── start.sh            # One-command startup
+├── stop.sh             # One-command shutdown
+└── logs/               # All service logs
 ```
 
-### Available Scripts
+---
 
-- `npm run dev` - Start development server
-- `npm run build` - Build for production
-- `npm run preview` - Preview production build
-- `./start.sh` - Start both API and frontend
-- `./stop.sh` - Stop all services
+## 🧩 Troubleshooting
 
-## Troubleshooting
+- **Internal Server Error?**  
+  Check `logs/api.log` and `logs/maestro.log` for Python tracebacks.
+- **Frontend not loading?**  
+  Make sure `npm install` completed and check `logs/builder.log`.
+- **Maestro backend not responding?**  
+  Check `logs/maestro.log` and ensure the correct mode was chosen.
 
-### API Connection Issues
+---
 
-1. Ensure the API server is running on `http://localhost:8000`
-2. Check that CORS is properly configured in the API
-3. Verify the API endpoint in `src/services/api.ts`
+## 🤝 Contributing
 
-### YAML Not Updating
+1. Fork the repo and create a feature branch.
+2. Make your changes and add tests if needed.
+3. Open a pull request!
 
-1. Check the browser console for errors
-2. Verify the API response format
-3. Ensure the YAML panel is properly connected
+---
 
-### Diff Not Showing Colors
-
-1. Check that you're in diff mode (toggle button in YAML panel)
-2. Ensure there are actual changes to display
-3. Check browser console for any JavaScript errors
-
-### OpenAI Integration
-
-1. Set your `OPENAI_API_KEY` environment variable
-2. Restart the API server after setting the key
-3. Check API logs for authentication errors
-
-### Database Issues
-
-1. Check that the API has write permissions in its directory
-2. Verify SQLite is properly installed
-3. Check API logs for database connection errors
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Test the integration
-5. Submit a pull request
-
-## License
+## 📄 License
 
 This project is part of the Maestro framework and follows the same license terms.

--- a/src/components/YamlPanel.tsx
+++ b/src/components/YamlPanel.tsx
@@ -138,7 +138,7 @@ export function YamlPanel({ yamlFiles, isLoading = false }: YamlPanelProps) {
         <div className="px-4 py-2 bg-blue-50 border-b border-blue-200 text-xs text-blue-700 font-medium">
           Showing changes (green = added, red = removed)
         </div>
-        <div className="text-sm font-mono px-4 py-2 overflow-y-auto h-[500px] bg-white font-['Courier_New'] whitespace-pre">
+        <div className="text-sm font-mono px-4 py-2 overflow-y-auto flex-1 min-h-0 bg-white font-['Courier_New'] whitespace-pre">
           {lines.map((line, idx) => {
             const lineStyle = line.type === 'insert'
               ? { backgroundColor: '#dcfce7', color: '#166534' } // green-100 bg, green-800 text
@@ -164,7 +164,7 @@ export function YamlPanel({ yamlFiles, isLoading = false }: YamlPanelProps) {
   const hasContent = filesToShow.some(file => file.content.trim() !== '')
 
   return (
-    <div className="w-1/3 border-l border-gray-100 bg-white flex flex-col">
+    <div className="w-1/3 h-full border-l border-gray-100 bg-white flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between p-6 border-b border-gray-100">
         <h2 className="text-lg font-semibold text-gray-900">Generated Files</h2>

--- a/src/components/YamlPanel.tsx
+++ b/src/components/YamlPanel.tsx
@@ -138,7 +138,7 @@ export function YamlPanel({ yamlFiles, isLoading = false }: YamlPanelProps) {
         <div className="px-4 py-2 bg-blue-50 border-b border-blue-200 text-xs text-blue-700 font-medium">
           Showing changes (green = added, red = removed)
         </div>
-        <div className="text-sm font-mono px-4 py-2 overflow-y-auto flex-1 min-h-0 bg-white font-['Courier_New'] whitespace-pre">
+        <div className="text-sm font-mono px-4 py-2 overflow-y-auto h-[500px] bg-white font-['Courier_New'] whitespace-pre">
           {lines.map((line, idx) => {
             const lineStyle = line.type === 'insert'
               ? { backgroundColor: '#dcfce7', color: '#166534' } // green-100 bg, green-800 text
@@ -164,7 +164,7 @@ export function YamlPanel({ yamlFiles, isLoading = false }: YamlPanelProps) {
   const hasContent = filesToShow.some(file => file.content.trim() !== '')
 
   return (
-    <div className="w-1/3 h-full border-l border-gray-100 bg-white flex flex-col">
+    <div className="w-1/3 border-l border-gray-100 bg-white flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between p-6 border-b border-gray-100">
         <h2 className="text-lg font-semibold text-gray-900">Generated Files</h2>

--- a/start.sh
+++ b/start.sh
@@ -54,6 +54,22 @@ wait_for_service() {
 check_port 8001 && print_warning "API already running on port 8001"
 (check_port 5174) && print_warning "Builder frontend already running on port 5174"
 
+# Mode selection for Maestro backend
+MODE=$1
+if [ "$MODE" = "workflow" ]; then
+  MAESTRO_CMD="maestro serve ./meta-agents-v2/workflow_file_generation/agents.yaml ./meta-agents-v2/workflow_file_generation/workflow.yaml"
+elif [ "$MODE" = "agents" ] || [ -z "$MODE" ]; then
+  MAESTRO_CMD="maestro serve ./meta-agents-v2/agents_file_generation/agents.yaml ./meta-agents-v2/agents_file_generation/workflow.yaml"
+else
+  echo "Usage: ./start.sh [agents|workflow]"
+  exit 1
+fi
+
+print_status "Starting Maestro backend: $MAESTRO_CMD"
+nohup $MAESTRO_CMD > logs/maestro.log 2>&1 &
+MAESTRO_PID=$!
+print_success "Maestro backend started with PID: $MAESTRO_PID"
+
 ### ───────────── Start API ─────────────
 
 print_status "Starting Maestro API service..."

--- a/stop.sh
+++ b/stop.sh
@@ -87,6 +87,7 @@ print_status "Stopping Maestro services..."
 # Stop services by port (more reliable than PID files)
 kill_process_by_port 8001 "API service"
 kill_process_by_port 5174 "Builder frontend"
+kill_process_by_port 8000 "Maestro backend"
 
 # Final verification
 echo ""
@@ -94,6 +95,7 @@ print_status "Verifying services are stopped..."
 
 api_stopped=true
 builder_stopped=true
+maestro_stopped=true
 
 if check_port 8001; then
     print_error "API service is still running on port 8001"
@@ -105,7 +107,12 @@ if check_port 5174; then
     builder_stopped=false
 fi
 
-if [ "$api_stopped" = true ] && [ "$builder_stopped" = true ]; then
+if check_port 8000; then
+    print_error "Maestro backend is still running on port 8000"
+    maestro_stopped=false
+fi
+
+if [ "$api_stopped" = true ] && [ "$builder_stopped" = true ] && [ "$maestro_stopped" = true ]; then
     print_success "All Maestro services have been stopped successfully!"
 else
     print_error "Some services may still be running. You may need to manually stop them."

--- a/stop.sh
+++ b/stop.sh
@@ -129,4 +129,4 @@ if [ -f "logs/builder.log" ]; then
 fi
 
 echo ""
-echo "To start services again, run: cd builder && ./start.sh" 
+echo "To start services again, run: ./start.sh [agents|workflow]" 


### PR DESCRIPTION
fixes #6 Simplifies the user experience so that they no longer have to explicity call maestro serve, rather just use the ./start.sh script.
Can still see the logs, which are written automatically to maestro.log.
Also updated the readme to reflect this change.
