### PR TITLE
feature: validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: Run Python Tests
 
 on:
   pull_request:
-    branches:
-      - main
-      - '**'
+    branches: [ main ]
 
 jobs:
   test:
@@ -26,7 +24,7 @@ jobs:
           pip install --upgrade pip
           pip install -r api/requirements.txt
           pip install pytest requests
-          pip install git+https://github.com/AI4quantum/maestro.git@v0.3.0
+          pip install git+https://github.com/AI4quantum/maestro.git@main
           pip install "beeai-framework[duckduckgo]"
 
       - name: Check maestro CLI installation
@@ -38,4 +36,4 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest tests/ 
+          pytest tests/ -v 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,4 +8,4 @@ openai>=1.76.2
 jsonschema>=4.23.0
 requests>=2.31.0 
 beeai-framework[duckduckgo]
-git+https://github.com/AI4quantum/maestro.git@v0.3.0 
+git+https://github.com/AI4quantum/maestro.git@main 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -35,6 +35,12 @@ export interface ChatSession {
   yaml_files: Record<string, string>
 }
 
+export interface ValidateYamlResponse {
+  is_valid: boolean
+  message: string
+  errors: string[]
+}
+
 export interface ChatHistory {
   id: string
   name: string
@@ -270,6 +276,34 @@ class ApiService {
     } catch (error) {
       console.error('Health check failed:', error)
       return false
+    }
+  }
+
+  async validateYaml(yamlContent: string, fileType: 'agents' | 'workflow'): Promise<ValidateYamlResponse> {
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/validate_yaml`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          yaml_content: yamlContent,
+          file_type: fileType
+        })
+      })
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+
+      return await response.json()
+    } catch (error) {
+      console.error('Error validating YAML:', error)
+      return {
+        is_valid: false,
+        message: 'Failed to validate YAML. Please check your connection and try again.',
+        errors: [error instanceof Error ? error.message : 'Unknown error']
+      }
     }
   }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,75 @@
+# Maestro Builder Tests
+
+This directory contains tests for the Maestro Builder application.
+
+## Test Files
+
+- `test_validation.py` - Tests for YAML validation functionality
+- `test_api.py` - Tests for API endpoints
+- `test_frontend.py` - Tests for frontend structure and dependencies
+- `complex_agents.yaml` - Complex multi-agent YAML file for testing validation
+
+## Running Tests
+
+### Local Testing
+
+```bash
+# Run all tests
+pytest tests/ -v
+
+# Run specific test categories
+pytest tests/test_validation.py -v
+pytest tests/test_api.py -v
+pytest tests/test_frontend.py -v
+
+# Run specific test
+pytest tests/test_frontend.py::test_frontend_files_exist -v
+```
+
+### CI/CD Testing
+
+Tests are automatically run via GitHub Actions on:
+- Pull requests to `main` branch
+
+## Test Coverage
+
+### Validation Tests
+1. **Direct maestro validation** - Tests that `maestro validate` works correctly with complex YAML files
+2. **API validation endpoint (mocked)** - Tests the `/api/validate_yaml` endpoint using mocking
+3. **Error handling** - Tests both success and failure scenarios with mocked responses
+4. **Double-escaping handling** - Tests that the API correctly handles frontend-escaped YAML content
+
+### API Tests
+1. **Health endpoint** - Tests the `/api/health` endpoint
+2. **Root endpoint** - Tests the root API endpoint
+
+### Frontend Tests
+1. **File structure** - Verifies essential frontend files exist
+2. **Component structure** - Checks YamlPanel component has required functionality
+3. **API service** - Validates API service has expected methods and interfaces
+4. **Dependencies** - Ensures package.json has required dependencies
+5. **Build configuration** - Tests Vite configuration is valid
+
+## Test Approach
+
+### Mocking Strategy
+- **No real server required** - API tests use mocking to avoid starting actual servers
+- **Fast and reliable** - Tests run quickly without external dependencies
+- **Comprehensive coverage** - Tests both success and error cases
+- **CI-friendly** - Works reliably in automated environments
+
+### Test Types
+- **Direct validation** - Tests `maestro validate` command directly
+- **API function testing** - Tests the validation function with mocked subprocess calls
+- **Error case testing** - Tests how the API handles validation failures
+- **Frontend structure testing** - Tests file existence and basic structure without running servers
+
+## Adding New Tests
+
+To add new tests:
+
+1. Create test files in this directory following pytest conventions
+2. Use descriptive test function names starting with `test_`
+3. Use mocking for API tests to avoid external dependencies
+4. Ensure tests handle both success and failure cases
+5. Add tests to appropriate categories (validation, API, frontend) 

--- a/tests/complex_agents.yaml
+++ b/tests/complex_agents.yaml
@@ -1,0 +1,38 @@
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: text_extractor
+spec:
+  framework: code
+  mode: local
+  file_path: ./text_extractor.py
+  description: |
+    Extracts text from a document for analysis.
+  code: |
+    import requests
+    from bs4 import BeautifulSoup
+
+    def extract_text(url):
+        response = requests.get(url)
+        if response.status_code == 200:
+            soup = BeautifulSoup(response.text, 'html.parser')
+            return '\n'.join([p.text for p in soup.find_all('p')])
+        else:
+            return "Failed to fetch document"
+
+    extracted_text = extract_text("https://example.com/document.pdf")
+    print(extracted_text)
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: key_point_analyzer
+spec:
+  model: deepseek-r1:latest
+  framework: beeai
+  mode: remote
+  description: |
+    Identifies important information within the extracted text.
+  instructions: |
+    Analyze the provided text to extract key points and summarize them in a structured format.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from fastapi.testclient import TestClient
 from api.main import app
 import pytest
-import requests
 
 client = TestClient(app)
 
@@ -22,11 +21,4 @@ def test_api_root():
     assert resp.status_code == 200
     data = resp.json()
     assert "message" in data
-    assert data["message"].lower().startswith("maestro builder api")
-
-# --- Frontend port test (requires running frontend server) ---
-@pytest.mark.skip(reason="Frontend integration test; requires running frontend on port 5174.")
-def test_frontend_running():
-    resp = requests.get("http://localhost:5174", timeout=3)
-    assert resp.status_code == 200
-    assert "<!doctype html>" in resp.text.lower() 
+    assert data["message"].lower().startswith("maestro builder api") 

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,94 @@
+"""
+Simple frontend tests that don't require a running server.
+"""
+
+import pytest
+from pathlib import Path
+
+
+def test_frontend_files_exist():
+    """Test that essential frontend files exist."""
+    project_root = Path(__file__).parent.parent
+    
+    # Check for essential frontend files
+    essential_files = [
+        "src/App.tsx",
+        "src/main.tsx", 
+        "src/components/YamlPanel.tsx",
+        "src/services/api.ts",
+        "index.html",
+        "package.json",
+        "vite.config.ts"
+    ]
+    
+    for file_path in essential_files:
+        full_path = project_root / file_path
+        assert full_path.exists(), f"Frontend file missing: {file_path}"
+
+
+def test_yaml_panel_component_structure():
+    """Test that YamlPanel component has expected structure."""
+    yaml_panel_path = Path(__file__).parent.parent / "src/components/YamlPanel.tsx"
+    
+    assert yaml_panel_path.exists(), "YamlPanel.tsx not found"
+    
+    with open(yaml_panel_path, 'r') as f:
+        content = f.read()
+    
+    # Check for essential imports and functionality
+    assert "import { useState" in content, "Missing useState import"
+    assert "ValidateYamlResponse" in content, "Missing ValidateYamlResponse import"
+    assert "handleValidate" in content, "Missing validate handler"
+    assert "Validate" in content, "Missing Validate button"
+
+
+def test_api_service_structure():
+    """Test that API service has expected structure."""
+    api_service_path = Path(__file__).parent.parent / "src/services/api.ts"
+    
+    assert api_service_path.exists(), "api.ts not found"
+    
+    with open(api_service_path, 'r') as f:
+        content = f.read()
+    
+    # Check for essential API functionality
+    assert "validateYaml" in content, "Missing validateYaml method"
+    assert "ValidateYamlResponse" in content, "Missing ValidateYamlResponse interface"
+    assert "API_BASE_URL" in content, "Missing API_BASE_URL"
+
+
+def test_package_dependencies():
+    """Test that package.json has required dependencies."""
+    package_json_path = Path(__file__).parent.parent / "package.json"
+    
+    assert package_json_path.exists(), "package.json not found"
+    
+    import json
+    with open(package_json_path, 'r') as f:
+        package_data = json.load(f)
+    
+    # Check for essential dependencies
+    dependencies = package_data.get("dependencies", {})
+    dev_dependencies = package_data.get("devDependencies", {})
+    
+    # Essential React dependencies
+    assert "react" in dependencies, "Missing react dependency"
+    assert "react-dom" in dependencies, "Missing react-dom dependency"
+    
+    # Essential dev dependencies
+    assert "vite" in dev_dependencies, "Missing vite dev dependency"
+    assert "typescript" in dev_dependencies, "Missing typescript dev dependency"
+
+
+def test_vite_config():
+    """Test that Vite config exists and is valid."""
+    vite_config_path = Path(__file__).parent.parent / "vite.config.ts"
+    
+    assert vite_config_path.exists(), "vite.config.ts not found"
+    
+    with open(vite_config_path, 'r') as f:
+        content = f.read()
+    
+    # Check for essential Vite configuration
+    assert "defineConfig" in content, "Missing defineConfig"
+    assert "react" in content, "Missing react plugin" 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Test validation functionality for Maestro YAML files.
+"""
+
+import subprocess
+import os
+import sys
+import tempfile
+import shutil
+import pytest
+from pathlib import Path
+
+# Add the project root to the Python path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def test_complex_agents_validation():
+    """Test validation of complex multi-agent YAML file."""
+    # Get the test file path
+    test_file = Path(__file__).parent / "complex_agents.yaml"
+    
+    assert test_file.exists(), f"Test file not found: {test_file}"
+    
+    # Run maestro validate on the test file
+    result = subprocess.run(
+        ['maestro', 'validate', str(test_file)],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).parent.parent  # Run from project root
+    )
+    
+    assert result.returncode == 0, f"Validation failed: {result.stderr or result.stdout}"
+
+
+def test_api_validation_endpoint():
+    """Test the API validation endpoint with the complex YAML using mocking."""
+    import asyncio
+    from unittest.mock import patch, MagicMock
+    
+    # Read the test YAML file
+    test_file = Path(__file__).parent / "complex_agents.yaml"
+    with open(test_file, 'r') as f:
+        yaml_content = f.read()
+    
+    # Prepare the request payload (with double-escaping to simulate frontend)
+    import codecs
+    escaped_content = codecs.encode(yaml_content, 'unicode_escape').decode('utf-8')
+    
+    # Test successful validation
+    with patch('subprocess.run') as mock_run:
+        # Mock successful maestro validation
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "YAML file is valid."
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+        
+        # Import and test the API service directly
+        from api.main import validate_yaml
+        from api.main import ValidateYamlRequest
+        
+        # Create the request object
+        request = ValidateYamlRequest(
+            yaml_content=escaped_content,
+            file_type="agents"
+        )
+        
+        # Test the validation function directly (async)
+        result = asyncio.run(validate_yaml(request))
+        
+        assert result.is_valid, f"Validation failed: {result.errors}"
+
+
+def test_api_validation_error_case():
+    """Test the API validation endpoint with an error case using mocking."""
+    import asyncio
+    from unittest.mock import patch, MagicMock
+    
+    # Create invalid YAML content
+    invalid_yaml = "invalid: yaml: content:"
+    
+    # Prepare the request payload (with double-escaping to simulate frontend)
+    import codecs
+    escaped_content = codecs.encode(invalid_yaml, 'unicode_escape').decode('utf-8')
+    
+    # Test error validation
+    with patch('subprocess.run') as mock_run:
+        # Mock failed maestro validation
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "Error: Invalid YAML format"
+        mock_run.return_value = mock_result
+        
+        # Import and test the API service directly
+        from api.main import validate_yaml
+        from api.main import ValidateYamlRequest
+        
+        # Create the request object
+        request = ValidateYamlRequest(
+            yaml_content=escaped_content,
+            file_type="agents"
+        )
+        
+        # Test the validation function directly (async)
+        result = asyncio.run(validate_yaml(request))
+        
+        assert not result.is_valid, "Should have failed validation"
+        assert result.errors, "Should have error messages"
+
+
+if __name__ == "__main__":
+    # For backward compatibility, can still run as script
+    pytest.main([__file__]) 


### PR DESCRIPTION
fixes #29

Adding a validation button. Once a yaml is created this is avaliable to use. It would be the same as doing "maestro validate generated.yaml". If there's an error, it outputs the error to the frontend so user can edit and try again.


