### PR TITLE
chore: switch to openai local

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ A modern web-based interface for building Maestro agents and workflows using AI 
      ```bash
      uv run pip install -r api/requirements.txt
      ```
-
+   - Populate your .env file; needs to include OPENAI_API_KEY and OPENAI_BASE_URL
+   
 3. **Install frontend dependencies:**
    ```bash
    uv run npm install

--- a/meta-agents-v2/agents_file_generation/agents.yaml
+++ b/meta-agents-v2/agents_file_generation/agents.yaml
@@ -6,8 +6,8 @@ metadata:
     app: meta-agents-v2
 spec:
   model: deepseek-r1:latest
-  framework: beeai
-  mode: remote
+  framework: openai
+  mode: local
   description: "Parses user goals and converts them into a structured list of agents with descriptions."
   instructions: |
     You are a **task-to-agent planner** that takes a user's natural language input and outputs a list of agents needed to accomplish that task.
@@ -72,8 +72,8 @@ metadata:
     app: meta-agents-v2
 spec:
   model: deepseek-r1:latest
-  framework: beeai
-  mode: remote
+  framework: openai
+  mode: local
   description: "Generates valid agents.yaml files using either LLM or code agents depending on the task."
   instructions: |
     You are an Agent YAML Generator. Given a list of agent names and descriptions, output a *single YAML file* with all agents, separated by `---`.
@@ -107,8 +107,8 @@ spec:
         app: <generate>
     spec:
       model: deepseek-r1:latest
-      framework: beeai
-      mode: remote
+      framework: openai
+      mode: local
       description: |
         <short summary of purpose>
       instructions: |
@@ -145,8 +145,8 @@ spec:
         app: generated
     spec:
       model: deepseek-r1:latest
-      framework: beeai
-      mode: remote
+      framework: openai
+      mode: local
       description: |
         Summarizes the given file’s contents.
       instructions: |

--- a/meta-agents-v2/editing_agent/agents.yaml
+++ b/meta-agents-v2/editing_agent/agents.yaml
@@ -6,8 +6,8 @@ metadata:
     app: builder
 spec:
   model: deepseek-r1:latest
-  framework: beeai
-  mode: remote
+  framework: openai
+  mode: local
   description: |
     Edits the yaml file based on the user's input.
   instructions: |

--- a/meta-agents-v2/workflow_file_generation/agents.yaml
+++ b/meta-agents-v2/workflow_file_generation/agents.yaml
@@ -6,8 +6,8 @@ metadata:
     app: meta-agents-v2
 spec:
   model: deepseek-r1:latest
-  framework: beeai
-  mode: remote
+  framework: openai
+  mode: local
   description: |
     Generates a valid workflow.yaml by sequencing agents defined in agents.yaml.
     It infers execution order from the list and places the input prompt at the top.


### PR DESCRIPTION
I've switched away from using beeai by default to the openai framework since Aki helped identify the bug I had in my .env file. 

Now you guys should be able to test and use the builder, assuming you have the .env set up correctly (which is just the openai key set to ollama and the base url as that 11434 host)